### PR TITLE
fixed nth-child bug

### DIFF
--- a/clss-test.asd
+++ b/clss-test.asd
@@ -1,0 +1,21 @@
+#|
+ This file is a part of CLSS
+ (c) 2014 Shirakumo http://tymoon.eu (shinmera@tymoon.eu)
+ Author: Nicolas Hafner <shinmera@tymoon.eu>
+|#
+(in-package :cl-user)
+(defpackage clss-test-asd
+  (:use :cl :asdf))
+(in-package :clss-test-asd)
+
+(defsystem clss-test
+  :author "Nicolas Hafner <shinmera@tymoon.eu>"
+  :license "zlib"
+  :depends-on (:clss
+	       :prove)
+  :defsystem-depends-on (:prove-asdf)
+  :components ((:module "t"
+	        :components
+		((:test-file "pseudo-selectors"))))
+  :perform (test-op :after (op c)
+                    (funcall (intern #.(string :run) :prove) c)))

--- a/clss.asd
+++ b/clss.asd
@@ -21,5 +21,6 @@
                (:file "parser")
                (:file "engine")
                (:file "pseudo-selectors"))
+  :in-order-to ((test-op (test-op clss-test)))
   :depends-on (:array-utils
                :plump))

--- a/pseudo-selectors.lisp
+++ b/pseudo-selectors.lisp
@@ -13,10 +13,17 @@
   (cond ((string-equal n "odd") (oddp i))
         ((string-equal n "even") (evenp i))
         ((find #\n n)
-         (let ((ppos (position #\+ n)))
-           (if ppos
-               (= (+ (mod i (parse-integer n :junk-allowed T)) (parse-integer (subseq n (1+ ppos)))) 0)
-               (= (mod i (parse-integer n :junk-allowed T)) 0))))
+         (let ((a (let ((r (parse-integer n :junk-allowed t)))
+                    (cond (r r)
+                          ((eq #\- (elt n 0)) -1)
+                          (T 1))))
+               (b (let ((ppos (position #\+ n)))
+                    (if ppos
+                        (parse-integer (subseq n (1+ ppos)))
+                        0))))
+           (multiple-value-bind (quot rem)
+             (floor (- i b) a)
+             (and (zerop rem) (>= quot 0)))))
         (T (= (parse-integer n) i))))
 
 (define-pseudo-selector nth-child (node n)

--- a/t/pseudo-selectors.lisp
+++ b/t/pseudo-selectors.lisp
@@ -1,0 +1,37 @@
+(in-package :cl-user)
+(defpackage pseudo-selector-test
+  (:use
+    :cl
+    :prove
+    :clss)
+  (:import-from
+    :clss match-nth))
+(in-package :pseudo-selector-test)
+
+(defvar test-input '(1 2 3 4 5))
+
+(defmacro match-nth-is (n selected)
+  `(is (mapcar #'(lambda (i) (match-nth i ,n)) ',test-input) ,selected ,n))
+
+(plan nil)
+
+(match-nth-is "1" '(t nil nil nil nil))
+(match-nth-is "3" '(nil nil t nil nil))
+(match-nth-is "odd" '(t nil t nil t))
+(match-nth-is "even" '(nil t nil t nil))
+
+(match-nth-is "n" '(t t t t t))
+(match-nth-is "n+1" '(t t t t t))
+(match-nth-is "n+2" '(nil t t t t))
+(match-nth-is "n+3" '(nil nil t t t))
+
+(match-nth-is "-n+1" '(t nil nil nil nil))
+(match-nth-is "-n+2" '(t t nil nil nil))
+(match-nth-is "-n+3" '(t t t nil nil))
+
+(match-nth-is "2n" '(nil t nil t nil))
+(match-nth-is "2n+1" '(t nil t nil t))
+
+(match-nth-is "-2n+3" '(t nil t nil nil))
+
+(finalize)


### PR DESCRIPTION
I noticed an issue with the logic in the `match-nth` function.  When called like so:
`(match-nth 1 "n+2)` it returned `nil` when it fact it should evaluate to true.

I added tests to expected behavior and then fixed the code to pass the tests.

-Dan