### PR TITLE
Add ordered-select.

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -31,6 +31,7 @@
    #:match-selector
    
    #:select
+   #:ordered-select
 
    #:match-group-backwards
    #:node-matches-p)


### PR DESCRIPTION
This is a small addition to address #14 in the simplest way possible—by implementing a separate function explicitly ordering elements in the depth-first traversal order.

It runs relatively fast—3-5 times slower than `clss:select`, the _worst_ result I had with the (unreliable) benchmark from #14 was:
```
Evaluation took:
  0.000 seconds of real time
  0.001050 seconds of total run time (0.000943 user, 0.000107 system)
  100.00% CPU
  2,537,028 processor cycles
  130,784 bytes consed
```
but that's a reasonable price for node ordering.

@Shinmera, looks fine to you? A better naming idea?