### PR TITLE
pseudo-selectors: Fix :last-child selector.

### DIFF
--- a/pseudo-selectors.lisp
+++ b/pseudo-selectors.lisp
@@ -55,8 +55,9 @@
 
 (define-pseudo-selector last-child (node)
   (loop for i downfrom (1- (length (family node))) to 0
-        when (element-p node)
-          do (return (eq (elt (family node) i) node))))
+        for sibling = (aref (family node) i)
+        when (element-p sibling)
+          do (return (eq sibling node))))
 
 (define-pseudo-selector first-of-type (node)
   (loop for sibling across (family node)


### PR DESCRIPTION
This fixes `:last-child` selector—it was almost never matching the right element, and the reason was that it was checking the last-child-ness of the parent element, and not the children ones.

On a related note, @Shinmera, why do you use `family` in all of the CLSS selectors, even when `family-elements` would make much more sense?