### PR TITLE
Propagate return type from find-substring

### DIFF
--- a/engine.lisp
+++ b/engine.lisp
@@ -83,7 +83,7 @@ for the selector to the matcher."))
                   finally (test) (return NIL))))))))
 
 (declaim (ftype (function (list plump-dom:node)
-                          (values boolean))
+                          (values (or boolean string)))
                 match-constraint))
 (defun match-constraint (constraint node)
   "Attempts to match the CONSTRAINT form against the node.


### PR DESCRIPTION
Find this while scraping Hacker News:

``` lisp
(defvar post (dex:get (format nil "https://news.ycombinator.com/item?id=41385637")))
(defvar dom (plump:parse post))
(clss:select ".commtext" dom)
```
It throws type error about non-boolean being returned from `match-constraint` on SBCL. Rightfully so: `find-substring` used in `match-constraint` returns either NIL or a string. So the return type for `match-constraint` is infected with strings.

Other solutions welcome, it's your code and you know better!